### PR TITLE
Add rule to notify when ignored tests exceed a threshold

### DIFF
--- a/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitRuleSetProvider.kt
+++ b/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitRuleSetProvider.kt
@@ -4,5 +4,6 @@ import com.pinterest.ktlint.core.RuleSet
 import com.pinterest.ktlint.core.RuleSetProvider
 
 class JUnitRuleSetProvider : RuleSetProvider {
-    override fun get() = RuleSet("junit-ktlint-rules", JUnitTestDescriptionRule(), JUnitTestAssertionRule())
+    override fun get() =
+        RuleSet("junit-ktlint-rules", JUnitTestDescriptionRule(), JUnitTestAssertionRule(), MaximumIgnoredTestRule())
 }

--- a/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRule.kt
+++ b/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRule.kt
@@ -1,0 +1,35 @@
+package dev.arunvelsriram.ktlint.rulesets.junit
+
+import com.pinterest.ktlint.core.Rule
+import org.jetbrains.kotlin.com.intellij.lang.ASTNode
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
+
+class MaximumIgnoredTestRule : Rule("maximum-ignored-test") {
+
+    override fun visit(
+        node: ASTNode,
+        autoCorrect: Boolean,
+        emit: (offset: Int, errorMessage: String, canBeAutoCorrected: Boolean) -> Unit
+    ) {
+        if (ignoredTestsCount > IGNORED_TESTS_THRESHOLD) return
+        if (node.elementType == KtStubElementTypes.FUNCTION) {
+            val func = node.psi as KtFunction
+            func.annotationEntries.find {
+                it.text == IGNORE_ANNOTATION
+            }?.let {
+                if (ignoredTestsCount == IGNORED_TESTS_THRESHOLD) {
+                    emit(0, LINT_ERROR_MESSAGE, false)
+                }
+                ignoredTestsCount += 1
+            }
+        }
+    }
+
+    companion object {
+        private const val IGNORE_ANNOTATION = "@Ignore"
+        private const val IGNORED_TESTS_THRESHOLD = 5
+        private const val LINT_ERROR_MESSAGE = "Number of ignored tests is greater than Threshold (5)"
+        private var ignoredTestsCount = 0
+    }
+}

--- a/src/test/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRuleTest.kt
+++ b/src/test/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRuleTest.kt
@@ -1,0 +1,74 @@
+package dev.arunvelsriram.ktlint.rulesets.junit
+
+import com.pinterest.ktlint.core.LintError
+import com.pinterest.ktlint.test.lint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class MaximumIgnoredTestRuleTest {
+
+    private val ruleId = "maximum-ignored-test"
+    private val lintErrorMessage = "Number of ignored tests is greater than Threshold (5)"
+
+    @Test
+    fun `should emit lint error only once when number of ignored test is greater than 5`() {
+        val code = """
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            } 
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            } 
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            } 
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            }
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            }
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            }
+            @Ignore
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            }
+            @Test
+            fun shouldAssertTrue() {
+                assertTrue(true)
+            }
+        """.trimIndent()
+
+        val result = MaximumIgnoredTestRule().lint(code)
+
+        val expected = listOf(LintError(1, 1, ruleId, lintErrorMessage))
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `should do nothing when number of ignored tests is within 5`() {
+        val code = """
+            @Test
+            fun `should assert true`() {
+                assertTrue(true)
+            }
+            @Ignore
+            fun `should assert false`() {
+                assertFalse(false)
+            }
+        """.trimIndent()
+
+        val result = MaximumIgnoredTestRule().lint(code)
+
+        assertTrue(result.isEmpty())
+    }
+}


### PR DESCRIPTION
Fixes #1 (https://github.com/arunvelsriram/ktlint-ruleset-junit/issues/1)

- Added the rule to notify when number of ignored tests are greater than 5
- It will notify only when and not for every additional ignored test
