### PR TITLE
Add dokka for documentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,26 +4,6 @@ Custom [ktlint](https://github.com/pinterest/ktlint) ruleset for linting [JUnit]
 
 [Link to bintray](https://bintray.com/arunvelsriram/maven/ktlint-ruleset-junit)
 
-## Rules
-
-`junit-test-description` - Checks if JUnit test description follows backticks style. For example,
-
-```kotlin
-@Test
-fun `should add two numbers`() {
-    assertEquals(3, add(1,2))
-}
-```
-
-`junit-test-assertion` - Checks if JUnit test asserts anything. For example,
-
-```kotlin
-@Test
-fun `should pass when test body asserts`() {
-    assertTrue(true)
-}
-```
-
 ## Setup
 
 * Add repository:
@@ -52,7 +32,7 @@ dependencies {
 * Install [OpenJDK11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot)
 * Install [IntelliJ IDEA](https://www.jetbrains.com/idea/)
 
-### Run test and build:
+### Run test, build and generate documentation:
 
 ```bash
 ./gradlew clean build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,11 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import java.util.Date
+import org.jetbrains.dokka.gradle.DokkaTask
 
 plugins {
     kotlin("jvm") version "1.3.50"
     id("com.jfrog.bintray") version "1.8.4"
+    id("org.jetbrains.dokka") version "0.10.0"
 }
 
 group = "dev.arunvelsriram.ktlint.rulesets.junit"
@@ -27,8 +29,15 @@ dependencies {
     testImplementation("com.pinterest.ktlint:ktlint-test:0.34.2")
 }
 
+tasks.build { finalizedBy("dokka") }
+
 tasks.withType<KotlinCompile> {
     kotlinOptions.jvmTarget = "1.8"
+}
+
+val dokka by tasks.getting(DokkaTask::class) {
+    outputFormat = "markdown"
+    outputDirectory = "$rootDir/documentation"
 }
 
 val test by tasks.getting(Test::class) {

--- a/documentation/ktlint-ruleset-junit/alltypes/index.md
+++ b/documentation/ktlint-ruleset-junit/alltypes/index.md
@@ -1,0 +1,30 @@
+
+
+### All Types
+
+|
+
+##### [dev.arunvelsriram.ktlint.rulesets.junit.JUnitRuleSetProvider](../dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/index.md)
+
+
+|
+
+##### [dev.arunvelsriram.ktlint.rulesets.junit.JUnitTestAssertionRule](../dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/index.md)
+
+This rule checks if JUnit test asserts anything.
+
+
+|
+
+##### [dev.arunvelsriram.ktlint.rulesets.junit.JUnitTestDescriptionRule](../dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/index.md)
+
+This rule checks if JUnit test description follows backticks style.
+
+
+|
+
+##### [dev.arunvelsriram.ktlint.rulesets.junit.MaximumIgnoredTestRule](../dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/index.md)
+
+This rule checks if the maximum ignored tests present exceeds the threshold (5)
+
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/-init-.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/-init-.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitRuleSetProvider](index.md) / [&lt;init&gt;](./-init-.md)
+
+# &lt;init&gt;
+
+`JUnitRuleSetProvider()`

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/get.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/get.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitRuleSetProvider](index.md) / [get](./get.md)
+
+# get
+
+`fun get(): RuleSet`

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/index.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-rule-set-provider/index.md
@@ -1,0 +1,14 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitRuleSetProvider](./index.md)
+
+# JUnitRuleSetProvider
+
+`class JUnitRuleSetProvider : RuleSetProvider`
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | `JUnitRuleSetProvider()` |
+
+### Functions
+
+| [get](get.md) | `fun get(): RuleSet` |
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/-init-.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/-init-.md
@@ -1,0 +1,15 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestAssertionRule](index.md) / [&lt;init&gt;](./-init-.md)
+
+# &lt;init&gt;
+
+`JUnitTestAssertionRule()`
+
+This rule checks if JUnit test asserts anything.
+
+```
+@Test
+fun `should pass when test body asserts`() {
+assertTrue(true)
+}
+```
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/-l-i-n-t_-e-r-r-o-r_-m-e-s-s-a-g-e.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/-l-i-n-t_-e-r-r-o-r_-m-e-s-s-a-g-e.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestAssertionRule](index.md) / [LINT_ERROR_MESSAGE](./-l-i-n-t_-e-r-r-o-r_-m-e-s-s-a-g-e.md)
+
+# LINT_ERROR_MESSAGE
+
+`const val LINT_ERROR_MESSAGE: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/index.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/index.md
@@ -1,0 +1,27 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestAssertionRule](./index.md)
+
+# JUnitTestAssertionRule
+
+`class JUnitTestAssertionRule : Rule`
+
+This rule checks if JUnit test asserts anything.
+
+```
+@Test
+fun `should pass when test body asserts`() {
+assertTrue(true)
+}
+```
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | This rule checks if JUnit test asserts anything.`JUnitTestAssertionRule()` |
+
+### Functions
+
+| [visit](visit.md) | `fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+
+### Companion Object Properties
+
+| [LINT_ERROR_MESSAGE](-l-i-n-t_-e-r-r-o-r_-m-e-s-s-a-g-e.md) | `const val LINT_ERROR_MESSAGE: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html) |
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/visit.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-assertion-rule/visit.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestAssertionRule](index.md) / [visit](./visit.md)
+
+# visit
+
+`fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/-init-.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/-init-.md
@@ -1,0 +1,15 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestDescriptionRule](index.md) / [&lt;init&gt;](./-init-.md)
+
+# &lt;init&gt;
+
+`JUnitTestDescriptionRule()`
+
+This rule checks if JUnit test description follows backticks style.
+
+```
+@Test
+fun `should add two numbers`() {
+assertEquals(3, add(1,2))
+}
+```
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/index.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/index.md
@@ -1,0 +1,23 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestDescriptionRule](./index.md)
+
+# JUnitTestDescriptionRule
+
+`class JUnitTestDescriptionRule : Rule`
+
+This rule checks if JUnit test description follows backticks style.
+
+```
+@Test
+fun `should add two numbers`() {
+assertEquals(3, add(1,2))
+}
+```
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | This rule checks if JUnit test description follows backticks style.`JUnitTestDescriptionRule()` |
+
+### Functions
+
+| [visit](visit.md) | `fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/visit.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-j-unit-test-description-rule/visit.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [JUnitTestDescriptionRule](index.md) / [visit](./visit.md)
+
+# visit
+
+`fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/-init-.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/-init-.md
@@ -1,0 +1,8 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [MaximumIgnoredTestRule](index.md) / [&lt;init&gt;](./-init-.md)
+
+# &lt;init&gt;
+
+`MaximumIgnoredTestRule()`
+
+This rule checks if the maximum ignored tests present exceeds the threshold (5)
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/index.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/index.md
@@ -1,0 +1,16 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [MaximumIgnoredTestRule](./index.md)
+
+# MaximumIgnoredTestRule
+
+`class MaximumIgnoredTestRule : Rule`
+
+This rule checks if the maximum ignored tests present exceeds the threshold (5)
+
+### Constructors
+
+| [&lt;init&gt;](-init-.md) | This rule checks if the maximum ignored tests present exceeds the threshold (5)`MaximumIgnoredTestRule()` |
+
+### Functions
+
+| [visit](visit.md) | `fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html) |
+

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/visit.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/-maximum-ignored-test-rule/visit.md
@@ -1,0 +1,5 @@
+[ktlint-ruleset-junit](../../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](../index.md) / [MaximumIgnoredTestRule](index.md) / [visit](./visit.md)
+
+# visit
+
+`fun visit(node: ASTNode, autoCorrect: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`, emit: (offset: `[`Int`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-int/index.html)`, errorMessage: `[`String`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-string/index.html)`, canBeAutoCorrected: `[`Boolean`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-boolean/index.html)`) -> `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)`): `[`Unit`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-unit/index.html)

--- a/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/index.md
+++ b/documentation/ktlint-ruleset-junit/dev.arunvelsriram.ktlint.rulesets.junit/index.md
@@ -1,0 +1,11 @@
+[ktlint-ruleset-junit](../index.md) / [dev.arunvelsriram.ktlint.rulesets.junit](./index.md)
+
+## Package dev.arunvelsriram.ktlint.rulesets.junit
+
+### Types
+
+| [JUnitRuleSetProvider](-j-unit-rule-set-provider/index.md) | `class JUnitRuleSetProvider : RuleSetProvider` |
+| [JUnitTestAssertionRule](-j-unit-test-assertion-rule/index.md) | This rule checks if JUnit test asserts anything.`class JUnitTestAssertionRule : Rule` |
+| [JUnitTestDescriptionRule](-j-unit-test-description-rule/index.md) | This rule checks if JUnit test description follows backticks style.`class JUnitTestDescriptionRule : Rule` |
+| [MaximumIgnoredTestRule](-maximum-ignored-test-rule/index.md) | This rule checks if the maximum ignored tests present exceeds the threshold (5)`class MaximumIgnoredTestRule : Rule` |
+

--- a/documentation/ktlint-ruleset-junit/index.md
+++ b/documentation/ktlint-ruleset-junit/index.md
@@ -1,0 +1,9 @@
+[ktlint-ruleset-junit](./index.md)
+
+### Packages
+
+| [dev.arunvelsriram.ktlint.rulesets.junit](dev.arunvelsriram.ktlint.rulesets.junit/index.md) |  |
+
+### Index
+
+[All Types](alltypes/index.md)

--- a/documentation/ktlint-ruleset-junit/package-list
+++ b/documentation/ktlint-ruleset-junit/package-list
@@ -1,0 +1,4 @@
+$dokka.format:markdown
+$dokka.linkExtension:md
+
+dev.arunvelsriram.ktlint.rulesets.junit

--- a/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitTestAssertionRule.kt
+++ b/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitTestAssertionRule.kt
@@ -5,6 +5,16 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
+/**
+This rule checks if JUnit test asserts anything.
+
+```
+@Test
+fun `should pass when test body asserts`() {
+    assertTrue(true)
+}
+```
+**/
 class JUnitTestAssertionRule : Rule("junit-test-assertion") {
 
     override fun visit(

--- a/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitTestDescriptionRule.kt
+++ b/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/JUnitTestDescriptionRule.kt
@@ -5,6 +5,16 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
+/**
+This rule checks if JUnit test description follows backticks style.
+
+```
+@Test
+fun `should add two numbers`() {
+    assertEquals(3, add(1,2))
+}
+```
+**/
 class JUnitTestDescriptionRule : Rule("junit-test-description") {
 
     override fun visit(

--- a/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRule.kt
+++ b/src/main/kotlin/dev/arunvelsriram/ktlint/rulesets/junit/MaximumIgnoredTestRule.kt
@@ -5,6 +5,9 @@ import org.jetbrains.kotlin.com.intellij.lang.ASTNode
 import org.jetbrains.kotlin.psi.KtFunction
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
+/**
+This rule checks if the maximum ignored tests present exceeds the threshold (5)
+**/
 class MaximumIgnoredTestRule : Rule("maximum-ignored-test") {
 
     override fun visit(


### PR DESCRIPTION
Fixes [#8](https://github.com/arunvelsriram/ktlint-ruleset-junit/issues/8)

- Integrated documentation using dokka
- We can still look into options on how to consolidate the documentation generated at each rule level.